### PR TITLE
Feature: support python projects with a requirements.txt

### DIFF
--- a/config.go
+++ b/config.go
@@ -341,7 +341,9 @@ func nodejs(c *Config) error {
 
 // python config.
 func python(c *Config) {
-	c.Proxy.Command = "python app.py"
+	if c.Proxy.Command == "" {
+		c.Proxy.Command = "python app.py"
+	}
 
 	// Only add build & clean hooks if a requiremnts.txt exists
 	if !util.Exists("requirements.txt") {

--- a/config.go
+++ b/config.go
@@ -145,7 +145,7 @@ func (c *Config) Default() error {
 	case util.Exists("app.js"):
 		c.Proxy.Command = "node app.js"
 	case util.Exists("app.py"):
-		c.Proxy.Command = "python app.py"
+		python(c)
 	case util.Exists("index.html"):
 		c.Type = "static"
 	}
@@ -337,4 +337,30 @@ func nodejs(c *Config) error {
 	}
 
 	return nil
+}
+
+// python config.
+func python(c *Config) {
+	c.Proxy.Command = "python app.py"
+
+	// Only add build & clean hooks if a requiremnts.txt exists
+	if !util.Exists("requirements.txt") {
+		return
+	}
+
+	// Set PYTHONPATH env
+	if c.Environment == nil {
+		c.Environment = config.Environment{}
+	}
+	c.Environment["PYTHONPATH"] = ".pypath/"
+
+	// Copy libraries into .pypath/
+	if c.Hooks.Build == "" {
+		c.Hooks.Build = `mkdir -p .pypath/ && pip install -r requirements.txt -t .pypath/`
+	}
+
+	// Clean .pypath/
+	if c.Hooks.Clean == "" {
+		c.Hooks.Clean = `rm -r .pypath/`
+	}
 }


### PR DESCRIPTION
This adds support for `requirements.txt` and using external libraries in `python`.

## Example

Here's an example using `bottle` for more complex routing (JSON responses, etc ...): 

```py
import os
from bottle import route, run, template

@route('/')
def hello():
    return "hello"

@route('/hello/<name>')
def hello(name):
    return template('Hello <b>{{name}}</b>!', name=name)

run(port=int(os.environ.get('PORT', 8080)))
```

## Shorter example

Similar to the current python example (slightly simpler/shorter with `bottle`):

```py
import os
from bottle import route, run

@route('/')
def hello():
    return "Hello World from Python"

run(port=int(os.environ['PORT']))
```

## Demo

https://ae2t1y6bfc.execute-api.eu-west-1.amazonaws.com/development/hello/TJ