### PR TITLE
Improve filtering/prioritization via tj/go-archive

### DIFF
--- a/internal/zip/zip.go
+++ b/internal/zip/zip.go
@@ -50,8 +50,9 @@ func Build(dir string) (io.ReadCloser, *archive.Stats, error) {
 		gitignore,
 		strings.NewReader("\n"),
 		npmignore,
-		strings.NewReader("\n!node_modules\n"),
-		upignore)
+		strings.NewReader("\n"),
+		upignore,
+		strings.NewReader("\n!main\n!_proxy.js\n!byline.js\n!up.json\n"))
 
 	filter, err := archive.FilterPatterns(r)
 	if err != nil {


### PR DESCRIPTION
Relies on https://github.com/tj/go-archive/pull/3
Also gives lower presence to `.upignore` after the UX step; see #84

fixes #50 