### PR TITLE
[WIP] Add build/clean cycle to start cmd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -123,6 +123,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/golang/sync"
+  packages = ["errgroup"]
+  revision = "f52d1811a62927559de87708c8913c1650ce4f26"
+
+[[projects]]
+  branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
   revision = "44e0413e5b74655281275e8c90cff2b27d9673a1"
@@ -266,10 +272,10 @@
   revision = "8403a29dbcbcdfeed7da1a251c56882923d28bc9"
 
 [[projects]]
+  branch = "master"
   name = "github.com/tj/go-archive"
   packages = ["."]
-  revision = "620d4ac08dcde19d96bf6812e60a75c981df403c"
-  version = "v1.0.1"
+  revision = "80d84dabd40cca694a2920b94c5d054737014500"
 
 [[projects]]
   branch = "master"
@@ -352,6 +358,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7bc3a3bccb1794e772c8cf759f1ee2ccdd39a81874eef4997ef6380af99da680"
+  inputs-digest = "6c67c8dcc0b096e550743014eb998165dd7142b9724f8134c0603fe1529bf12f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/internal/cli/start/start.go
+++ b/internal/cli/start/start.go
@@ -20,9 +20,13 @@ func init() {
 	addr := cmd.Flag("address", "Address for server.").Default(":3000").String()
 
 	cmd.Action(func(_ *kingpin.ParseContext) error {
-		_, _, err := root.Init()
+		_, p, err := root.Init()
 		if err != nil {
 			return errors.Wrap(err, "initializing")
+		}
+
+		if err := p.Build(); err != nil {
+			return errors.Wrap(err, "building")
 		}
 
 		stats.Track("Start", map[string]interface{}{

--- a/internal/cli/start/start.go
+++ b/internal/cli/start/start.go
@@ -2,6 +2,7 @@ package start
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/apex/log"
 	"github.com/pkg/errors"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/apex/up/handler"
 	"github.com/apex/up/internal/cli/root"
+	"github.com/apex/up/internal/signals"
 	"github.com/apex/up/internal/stats"
 )
 
@@ -31,6 +33,12 @@ func init() {
 
 		stats.Track("Start", map[string]interface{}{
 			"address": *addr,
+		})
+
+		signals.AddCloser(func(_ os.Signal) {
+			if err := p.RunHook("clean"); err != nil {
+				errors.Wrap(err, "cleaning")
+			}
 		})
 
 		h, err := handler.New()

--- a/internal/signals/signals.go
+++ b/internal/signals/signals.go
@@ -1,0 +1,39 @@
+package signals
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+type closer func(os.Signal)
+
+var (
+	signals  = make(chan os.Signal, 1)
+	exit     = make(chan bool, 1)
+	closers  = make([]closer, 0)
+	incoming os.Signal
+)
+
+// Init signals channel
+func root() {
+	signals = make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT)
+}
+
+// Add closer
+func AddCloser(fn closer) {
+	closers = append([]closer{fn}, closers...)
+}
+
+// Capture all signals
+func Capture() {
+	go func() {
+		<-signals
+		for _, fn := range closers {
+			fmt.Println("Executing")
+			fn(incoming)
+		}
+	}()
+}

--- a/internal/signals/signals.go
+++ b/internal/signals/signals.go
@@ -1,10 +1,11 @@
 package signals
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/apex/log"
 )
 
 type closer func(os.Signal)
@@ -17,7 +18,8 @@ var (
 )
 
 // Init signals channel
-func root() {
+func init() {
+	log.Infof("Root\n")
 	signals = make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT)
 }
@@ -32,7 +34,7 @@ func Capture() {
 	go func() {
 		<-signals
 		for _, fn := range closers {
-			fmt.Println("Executing")
+			log.Infof("Executing\n")
 			fn(incoming)
 		}
 	}()


### PR DESCRIPTION
### Hooks
- [x] build
- [ ] clean

At [cmd/up/main.go#L62](https://github.com/apex/up/blob/master/cmd/up/main.go#L62) we're trapping all signals, I imagine all `up(1)` commands will get a shutdown function allowing them to access the signals... This way each cmd can choose to handle shutdown as they please.

NOTE: this would also enable rollback functionality when killed via `^C`.