### PR TITLE
Delegate default region to aws sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ up-proxy
 !cmd/up-proxy
 dist
 .idea
+.vscode

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -123,6 +123,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/golang/sync"
+  packages = ["errgroup"]
+  revision = "f52d1811a62927559de87708c8913c1650ce4f26"
+
+[[projects]]
+  branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
   revision = "44e0413e5b74655281275e8c90cff2b27d9673a1"
@@ -266,10 +272,10 @@
   revision = "8403a29dbcbcdfeed7da1a251c56882923d28bc9"
 
 [[projects]]
+  branch = "master"
   name = "github.com/tj/go-archive"
   packages = ["."]
-  revision = "620d4ac08dcde19d96bf6812e60a75c981df403c"
-  version = "v1.0.1"
+  revision = "80d84dabd40cca694a2920b94c5d054737014500"
 
 [[projects]]
   branch = "master"
@@ -352,6 +358,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7bc3a3bccb1794e772c8cf759f1ee2ccdd39a81874eef4997ef6380af99da680"
+  inputs-digest = "6c67c8dcc0b096e550743014eb998165dd7142b9724f8134c0603fe1529bf12f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apex/up/internal/util"
 	"github.com/apex/up/internal/validate"
 	"github.com/apex/up/platform/lambda/regions"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 // TODO: refactor defaulting / validation with slices
@@ -218,15 +219,21 @@ func (c *Config) defaultRegions() error {
 		return nil
 	}
 
-	if s := os.Getenv("AWS_REGION"); s != "" {
+	s, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		return err
+	}
+	if len(*s.Config.Region) > 0 {
 		log.Debugf("region from AWS_REGION %q", s)
-		c.Regions = append(c.Regions, s)
+		c.Regions = append(c.Regions, *s.Config.Region)
 		return nil
 	}
 
-	s := "us-west-2"
-	log.Debugf("region defaulted to %q", s)
-	c.Regions = append(c.Regions, s)
+	r := "us-west-2"
+	log.Debugf("region defaulted to %q", r)
+	c.Regions = append(c.Regions, r)
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -226,7 +226,7 @@ func (c *Config) defaultRegions() error {
 		return err
 	}
 	if len(*s.Config.Region) > 0 {
-		log.Debugf("region from AWS_REGION %q", s)
+		log.Debugf("region from aws shared config %q", s)
 		c.Regions = append(c.Regions, *s.Config.Region)
 		return nil
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package up
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -160,7 +161,9 @@ func TestConfig_defaultRegions(t *testing.T) {
 		}
 
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
+		assert.Equal(t, 2, len(c.Regions), "regions should have length 2")
 		assert.Equal(t, regions, c.Regions, "should read regions from config")
+		assert.NoError(t, c.Validate(), "validate")
 	})
 
 	t.Run("regions from AWS_REGION", func(t *testing.T) {
@@ -175,6 +178,7 @@ func TestConfig_defaultRegions(t *testing.T) {
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
 		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
 		assert.Equal(t, region, c.Regions[0], "should read regions from AWS_REGION")
+		assert.NoError(t, c.Validate(), "validate")
 	})
 
 	t.Run("regions from AWS_DEFAULT_REGION", func(t *testing.T) {
@@ -189,6 +193,97 @@ func TestConfig_defaultRegions(t *testing.T) {
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
 		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
 		assert.Equal(t, region, c.Regions[0], "should read regions from AWS_DEFAULT_REGION")
+		assert.NoError(t, c.Validate(), "validate")
 	})
 
+	t.Run("regions from AWS_DEFAULT_REGION", func(t *testing.T) {
+		region := "sa-east-1"
+		os.Setenv("AWS_DEFAULT_REGION", region)
+		defer os.Setenv("AWS_DEFAULT_REGION", "")
+		c := Config{
+			Name: "api",
+			Type: "server",
+		}
+
+		assert.NoError(t, c.defaultRegions(), "defaultRegions")
+		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
+		assert.Equal(t, region, c.Regions[0], "should read regions from AWS_DEFAULT_REGION")
+		assert.NoError(t, c.Validate(), "validate")
+	})
+
+	t.Run("regions from shared config with default profile", func(t *testing.T) {
+		content := `
+		[default]
+		region = sa-east-1
+		output = json
+		[profile another-profile]
+		region = ap-southeast-2
+		output = json`
+		tmpfile, err := ioutil.TempFile("", "config")
+		assert.NoError(t, err)
+		defer os.Remove(tmpfile.Name())
+
+		_, err = tmpfile.WriteString(content)
+		assert.NoError(t, err)
+
+		os.Setenv("AWS_CONFIG_FILE", tmpfile.Name())
+		defer os.Setenv("AWS_CONFIG_FILE", "")
+
+		c := Config{
+			Name: "api",
+			Type: "server",
+		}
+
+		assert.NoError(t, c.defaultRegions(), "defaultRegions")
+		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
+		assert.Equal(t, "sa-east-1", c.Regions[0], "should read regions from shared config with default profile")
+		assert.NoError(t, c.Validate(), "validate")
+	})
+
+	t.Run("regions from shared config with AWS_PROFILE profile", func(t *testing.T) {
+		content := `
+		[default]
+		region = sa-east-1
+		output = json
+		[profile another-profile]
+		region = ap-southeast-2
+		output = json`
+		tmpfile, err := ioutil.TempFile("", "config")
+		assert.NoError(t, err)
+		defer os.Remove(tmpfile.Name())
+
+		_, err = tmpfile.WriteString(content)
+		assert.NoError(t, err)
+
+		os.Setenv("AWS_CONFIG_FILE", tmpfile.Name())
+		defer os.Setenv("AWS_CONFIG_FILE", "")
+
+		os.Setenv("AWS_PROFILE", "another-profile")
+		defer os.Setenv("AWS_PROFILE", "")
+
+		c := Config{
+			Name: "api",
+			Type: "server",
+		}
+
+		assert.NoError(t, c.defaultRegions(), "defaultRegions")
+		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
+		assert.Equal(t, "ap-southeast-2", c.Regions[0], "should read regions from shared config with AWS_PROFILE profile")
+		assert.NoError(t, c.Validate(), "validate")
+	})
+
+	t.Run("default region must be us-west-2", func(t *testing.T) {
+		// Make sure we aren't reading AWS config file
+		os.Setenv("AWS_CONFIG_FILE", "does-not-exist")
+
+		c := Config{
+			Name: "api",
+			Type: "server",
+		}
+
+		assert.NoError(t, c.defaultRegions(), "defaultRegions")
+		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
+		assert.Equal(t, "us-west-2", c.Regions[0], "default region must be us-west-2")
+		assert.NoError(t, c.Validate(), "validate")
+	})
 }

--- a/config_test.go
+++ b/config_test.go
@@ -196,21 +196,6 @@ func TestConfig_defaultRegions(t *testing.T) {
 		assert.NoError(t, c.Validate(), "validate")
 	})
 
-	t.Run("regions from AWS_DEFAULT_REGION", func(t *testing.T) {
-		region := "sa-east-1"
-		os.Setenv("AWS_DEFAULT_REGION", region)
-		defer os.Setenv("AWS_DEFAULT_REGION", "")
-		c := Config{
-			Name: "api",
-			Type: "server",
-		}
-
-		assert.NoError(t, c.defaultRegions(), "defaultRegions")
-		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
-		assert.Equal(t, region, c.Regions[0], "should read regions from AWS_DEFAULT_REGION")
-		assert.NoError(t, c.Validate(), "validate")
-	})
-
 	t.Run("regions from shared config with default profile", func(t *testing.T) {
 		content := `
 		[default]


### PR DESCRIPTION
Close https://github.com/apex/up/issues/250.

If `regions` is not present in `up.json` delegates default region to aws sdk. More info about how this process works can be found [here](https://godoc.org/github.com/aws/aws-sdk-go/aws/session#hdr-Shared_Config_Fields) and [here](https://godoc.org/github.com/aws/aws-sdk-go/aws/session#hdr-Environment_Variables). Also the added [tests](https://github.com/apex/up/pull/255/files#diff-fb6a7899d06670e0e85669d2652ba911R154) try to enumerate them all.