### PR TITLE
Made changes to have a configurable timeout (not tested)

### DIFF
--- a/config/relay.go
+++ b/config/relay.go
@@ -14,12 +14,19 @@ type Relay struct {
 
 	// Backoff configuration.
 	Backoff Backoff `json:"backoff"`
+
+	//Timeout interval, Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	Timeout	string	`json:"timeout"` 
 }
 
 // Default implementation.
 func (r *Relay) Default() error {
 	if r.Command == "" {
 		r.Command = "./server"
+	}
+
+	if r.Timeout == "" {
+		r.Timeout = "5s"
 	}
 
 	if err := r.Backoff.Default(); err != nil {

--- a/config/relay.go
+++ b/config/relay.go
@@ -15,8 +15,8 @@ type Relay struct {
 	// Backoff configuration.
 	Backoff Backoff `json:"backoff"`
 
-	//Timeout interval, Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	Timeout	string	`json:"timeout"` 
+	// Timeout interval in seconds.
+	Timeout	int	`json:"timeout"` 
 }
 
 // Default implementation.

--- a/config/relay.go
+++ b/config/relay.go
@@ -25,8 +25,8 @@ func (r *Relay) Default() error {
 		r.Command = "./server"
 	}
 
-	if r.Timeout == "" {
-		r.Timeout = "5s"
+	if r.Timeout == 0 {
+		r.Timeout = 5
 	}
 
 	if err := r.Backoff.Default(); err != nil {

--- a/http/relay/relay.go
+++ b/http/relay/relay.go
@@ -83,7 +83,12 @@ func (p *Proxy) Start() error {
 
 	// TODO: configurable timeout
 	ctx.Infof("waiting for %s", p.target.String())
-	if err := waitForListen(p.target, 5*time.Second); err != nil {
+
+	timeout, err := time.ParseDuration(p.config.Proxy.Timeout);
+	if err != nil {
+		timeout = time.ParseDuration("5s")
+	}
+	if err := waitForListen(p.target, timeout); err != nil {
 		return errors.Wrapf(err, "waiting for %s to be in listening state", p.target.String())
 	}
 

--- a/http/relay/relay.go
+++ b/http/relay/relay.go
@@ -84,11 +84,7 @@ func (p *Proxy) Start() error {
 	// TODO: configurable timeout
 	ctx.Infof("waiting for %s", p.target.String())
 
-	timeout, err := time.ParseDuration(p.config.Proxy.Timeout);
-	if err != nil {
-		timeout = time.ParseDuration("5s")
-	}
-	if err := waitForListen(p.target, timeout); err != nil {
+	if err := waitForListen(p.target, p.config.Proxy.Timeout*time.Seconds); err != nil {
 		return errors.Wrapf(err, "waiting for %s to be in listening state", p.target.String())
 	}
 


### PR DESCRIPTION
This is for issue #264 
I kept 5 seconds as the default time if it fails to parse the time that they give. This relies on time.ParseDuration() which means you format it with a unit suffix (`Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"`). Didn't have time to test it but I'm sure it'll work 👍 