### PR TITLE
proxy: Allow bearer auth request to pass through proxy. Closes #287

### DIFF
--- a/internal/proxy/request.go
+++ b/internal/proxy/request.go
@@ -59,30 +59,46 @@ func NewRequest(e *Input) (*http.Request, error) {
 	// user
 	auth := req.Header.Get("Authorization")
 	if auth != "" {
-		user, pass, err := basic(auth)
+		authType, creds, err := parseAuthHeader(auth)
 		if err != nil {
-			return nil, errors.Wrap(err, "parsing basic auth")
+			return nil, errors.Wrap(err, "parsing auth header")
 		}
-		req.URL.User = url.UserPassword(user, pass)
+
+		// Specifically allow Basic auth to be parsed
+		// Purposefully ignore other kinds of auth, to allow them to trivially pass through
+		// by simply copying their headers
+		if strings.ToLower(authType) == "basic" {
+			userinfo, err := basic(creds)
+			if err != nil {
+				return nil, errors.Wrap(err, "parsing basic auth")
+			}
+
+			req.URL.User = userinfo
+		}
 	}
 
 	// TODO: pass the original json input
 	return req, nil
 }
 
-// basic auth parser.
-func basic(s string) (user, pass string, err error) {
+// parseAuthHeader will parse the authorization header to determine the type of auth used
+// in this request.
+func parseAuthHeader(s string) (authType, credentials string, err error) {
 	p := strings.SplitN(s, " ", 2)
-
-	if len(p) != 2 || p[0] != "Basic" {
+	if len(p) != 2 {
 		return "", "", errors.New("malformed")
 	}
 
-	b, err := base64.StdEncoding.DecodeString(p[1])
+	return p[0], p[1], nil
+}
+
+// basic parses credentials of an Authorization header, this assumes it is basic auth
+func basic(creds string) (userinfo *url.Userinfo, err error) {
+	b, err := base64.StdEncoding.DecodeString(creds)
 	if err != nil {
-		return "", "", errors.Wrap(err, "decoding")
+		return nil, errors.Wrap(err, "decoding")
 	}
 
-	pair := strings.SplitN(string(b), ":", 2)
-	return pair[0], pair[1], nil
+	p := strings.SplitN(string(b), ":", 2)
+	return url.UserPassword(p[0], p[1]), nil
 }

--- a/internal/proxy/request_test.go
+++ b/internal/proxy/request_test.go
@@ -62,4 +62,19 @@ func TestNewRequest(t *testing.T) {
 
 		assert.Equal(t, `Hello World`, string(b))
 	})
+
+	t.Run("Bearer Auth", func(t *testing.T) {
+		var in Input
+		err := json.Unmarshal([]byte(getEvent), &in)
+		assert.NoError(t, err, "unmarshal")
+
+		// Add Bearer auth
+		in.Headers["Authorization"] = "Bearer token"
+
+		req, err := NewRequest(&in)
+		assert.NoError(t, err, "new request")
+
+		assert.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+		assert.Equal(t, true, req.URL.User == nil)
+	})
 }


### PR DESCRIPTION
Fixes https://github.com/apex/up/issues/287

The up proxy is specifically trying to parse all auth types as Basic auth, however there are other kinds of authentication that we need to allow to passthrough untouched.

This PR does 2 specific things:
1. Small refactoring, code changes and tests to allow Bearer auth
1. Explicitly using the io.Reader from the `bytes` package for binary requests

Admittedly, 2 wasn't really necessary - so feel free to not accept it, cherry-pick it away, commandeer this PR, etc.

My experience with up was that I got it up and running very fast (usually testing on non-authenticated endpoints), however got quickly discouraged when cloudfront was returning `502 "Error from cloudfront"` on any _real_ requests.