### PR TITLE
formatting: fix the output for longer domain names

### DIFF
--- a/internal/cli/domains/domains.go
+++ b/internal/cli/domains/domains.go
@@ -188,7 +188,7 @@ func list(cmd *kingpin.CmdClause) {
 			if d.AutoRenew {
 				s = " renews"
 			}
-			fmt.Printf("  %-45s %s %s\n", colors.Purple(d.Name), s, d.Expiry.Format(time.Stamp))
+			fmt.Printf("  %-45s %s %s\n", colors.Purple(d.Name), s, d.Expiry.Format(time.RFC3339))
 		}
 
 		return nil

--- a/internal/cli/domains/domains.go
+++ b/internal/cli/domains/domains.go
@@ -188,7 +188,7 @@ func list(cmd *kingpin.CmdClause) {
 			if d.AutoRenew {
 				s = " renews"
 			}
-			fmt.Printf("  %-40s %s %s\n", colors.Purple(d.Name), s, d.Expiry.Format(time.Stamp))
+			fmt.Printf("  %-45s %s %s\n", colors.Purple(d.Name), s, d.Expiry.Format(time.Stamp))
 		}
 
 		return nil


### PR DESCRIPTION
When executing `up domains` and we get long domain it throws off the formatting

```
  autoaudit.com.au  renews Jan  2 05:39:05
  infrastructurepricing.com  renews Jan 13 10:59:50
  programites.com  renews Jul 20 03:50:13
  shareside.com  renews Mar 27 08:37:46
```

This is because the call to colors returns more than 40 characters. I have just pushed it up to 45 characters as a short term fix. The better fix maybe to pass the domain names and determine the longest length domain name, etc, etc

Explanation longer than the patch 