### PR TITLE
proxy: add handling for subprocess cleanup, retries

### DIFF
--- a/config.go
+++ b/config.go
@@ -118,6 +118,10 @@ func (c *Config) Validate() error {
 		return errors.Wrap(err, ".inject")
 	}
 
+	if err := c.Proxy.Validate(); err != nil {
+		return errors.Wrap(err, ".proxy")
+	}
+
 	return nil
 }
 

--- a/config/relay.go
+++ b/config/relay.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/jpillora/backoff"
@@ -28,6 +29,11 @@ func (r *Relay) Default() error {
 
 	if r.ListenTimeout == 0 {
 		r.ListenTimeout = 15
+	}
+
+	if r.ListenTimeout >= 30 {
+		err := fmt.Errorf("listen_timeout should be less 30s (APIGateway integration limit)")
+		return errors.Wrap(err, ".listen_timeout")
 	}
 
 	if err := r.Backoff.Default(); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -161,6 +161,7 @@ func TestConfig_defaultRegions(t *testing.T) {
 			Type:    "server",
 			Regions: regions,
 		}
+		assert.NoError(t, c.Default(), "default")
 
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
 		assert.Equal(t, 2, len(c.Regions), "regions should have length 2")
@@ -177,10 +178,12 @@ func TestConfig_defaultRegions(t *testing.T) {
 			Name: "api",
 			Type: "server",
 		}
+		assert.NoError(t, c.Default(), "default")
 
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
 		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
 		assert.Equal(t, region, c.Regions[0], "should read regions from AWS_REGION")
+		assert.NoError(t, c.Default(), "default")
 		assert.NoError(t, c.Validate(), "validate")
 	})
 
@@ -194,6 +197,7 @@ func TestConfig_defaultRegions(t *testing.T) {
 			Name: "api",
 			Type: "server",
 		}
+		assert.NoError(t, c.Default(), "default")
 
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
 		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
@@ -224,6 +228,7 @@ func TestConfig_defaultRegions(t *testing.T) {
 			Name: "api",
 			Type: "server",
 		}
+		assert.NoError(t, c.Default(), "default")
 
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
 		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
@@ -257,6 +262,7 @@ func TestConfig_defaultRegions(t *testing.T) {
 			Name: "api",
 			Type: "server",
 		}
+		assert.NoError(t, c.Default(), "default")
 
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
 		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")
@@ -272,6 +278,7 @@ func TestConfig_defaultRegions(t *testing.T) {
 			Name: "api",
 			Type: "server",
 		}
+		assert.NoError(t, c.Default(), "default")
 
 		assert.NoError(t, c.defaultRegions(), "defaultRegions")
 		assert.Equal(t, 1, len(c.Regions), "regions should have length 1")

--- a/docs/04-configuration.md
+++ b/docs/04-configuration.md
@@ -440,13 +440,15 @@ The following settings are available:
   - When `app.js` is detected `node app.js` is used
   - When `app.py` is detected `python app.py` is used
 - `backoff` – Backoff configuration object described in "Crash Recovery"
-- `listen_timeout` – Timeout in seconds Up will wait for your app to boot and listen on `PORT` (Default `15`)
+- `listen_timeout` – Timeout in seconds Up will wait for your app to boot and listen on `PORT` (Default `15`, Max `25`)
+- `shutdown_timeout` – Timeout in seconds Up will wait after sending a SIGINT to your server, before sending a SIGKILL (Default `15`)
 
 ```json
 {
   "proxy": {
     "command": "node app.js",
-    "listen_timeout": 30
+    "listen_timeout": 12,
+    "shutdown_timeout": 5
   }
 }
 ```
@@ -481,6 +483,8 @@ Here's an example tweaking the default behaviour:
   }
 }
 ```
+
+Since Up's purpose is to proxy your http traffic, Up will treat network errors as a crash.  When Up detects this, it will allow the server to cleanly close by sending a SIGINT, it the server does not close within `proxy.shutdown_timeout` seconds, it will forcibly close it with a SIGKILL.
 
 ## DNS Zones & Records
 

--- a/http/relay/relay.go
+++ b/http/relay/relay.go
@@ -201,6 +201,9 @@ func (p *Proxy) start() error {
 		return errors.Wrap(err, "parsing url")
 	}
 
+	p.port = port
+	p.target = target
+
 	ctx.Infof("executing %q", p.config.Proxy.Command)
 
 	cmd = exec.Command("sh", "-c", p.config.Proxy.Command)
@@ -212,9 +215,7 @@ func (p *Proxy) start() error {
 		return errors.Wrap(err, "running command")
 	}
 
-	// Only remember these properties it if was successfully started
-	p.port = port
-	p.target = target
+	// Only remember this if it was successfully started
 	p.cmd = cmd
 	ctx.Infof("proxy (pid=%d) started", cmd.Process.Pid)
 

--- a/http/relay/relay.go
+++ b/http/relay/relay.go
@@ -28,7 +28,6 @@ import (
 // TODO: add timeout
 // TODO: scope all plugin logs to their plugin name
 // TODO: utilize BufferPool
-// TODO: if the first Start() fails then bail
 
 // log context.
 var ctx = logs.Plugin("relay")

--- a/http/relay/testdata/basic/app.js
+++ b/http/relay/testdata/basic/app.js
@@ -61,7 +61,7 @@ routes['/close'] = (req, res) => {
   server.close(() => 1);
 
   res.writeHead(200, {
-    Connection: 'close',
+    Connection: 'close'
   });
 
   res.end('closed');

--- a/http/relay/testdata/basic/app.js
+++ b/http/relay/testdata/basic/app.js
@@ -1,51 +1,92 @@
-const http = require('http')
-const port = process.env.PORT
+const http = require('http');
+const url = require('url');
+const qs = require('querystring');
+const port = process.env.PORT;
 
-http.createServer((req, res) => {
-  if (req.url.indexOf('/echo') == 0) {
-    const buffers = []
-    req.on('data', b => buffers.push(b))
-    req.on('end', _ => {
-      const body = Buffer.concat(buffers).toString()
-      res.setHeader('Content-Type', 'application/json')
-      res.end(JSON.stringify({
-        header: req.headers,
-        url: req.url,
-        body
-      }, null, 2))
-    })
-    return
+let server;
+
+const routes = {};
+routes['/echo'] = (req, res) => {
+  const buffers = []
+  req.on('data', b => buffers.push(b))
+  req.on('end', _ => {
+    const body = Buffer.concat(buffers).toString()
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify({
+      header: req.headers,
+      url: req.url,
+      body
+    }, null, 2))
+  });
+};
+
+routes['/env'] = (req, res) => {
+  const query = qs.parse(url.parse(req.url).query);
+  res.end(process.env[query.key], 'utf8');
+};
+
+routes['/pid'] = (req, res) => {
+  res.end(String(process.pid), 'utf8');
+};
+
+routes['/throw/random'] = (req, res) => {
+  if (Math.random() > 0.75) {
+    yaynode();
   }
 
-  if (req.url.indexOf('/throw/random') == 0) {
-    if (Math.random() > 0.75) {
-      yaynode()
-    }
+  res.end('Hello');
+};
 
+routes['/throw/env'] = (req, res) => {
+  if (process.env.UP_RESTARTS != '2') {
+    yaynode();
+  }
+
+  res.end('Hello');
+};
+
+routes['/delay'] = (req, res) => {
+  setTimeout(function(){
     res.end('Hello')
-    return
+  }, Math.random() * 50000);
+};
+
+routes['/throw'] = (req, res) => {
+  yaynode()
+};
+
+
+// Close the server, so we can get network errors without ending the process
+routes['/close'] = (req, res) => {
+  server.close(() => 1);
+
+  res.writeHead(200, {
+    Connection: 'close',
+  });
+
+  res.end('closed');
+};
+
+routes['/swallowSignals'] = (req, res) => {
+  for (const s of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGUSR1', 'SIGUSR2']) {
+    process.on(s, () => 1);
   }
 
-  if (req.url.indexOf('/throw/env') == 0) {
-    if (process.env.UP_RESTARTS != '2') {
-      yaynode()
-    }
+  res.end('swallow');
+};
 
-    res.end('Hello')
-    return
-  }
-
-  if (req.url.indexOf('/delay') == 0) {
-    setTimeout(function(){
-      res.end('Hello')
-    }, Math.random() * 50000)
-    return
-  }
-
-  if (req.url.indexOf('/throw') == 0) {
-    yaynode()
+server = http.createServer((req, res) => {
+  const r = Object.keys(routes).find(pattern => req.url.indexOf(pattern) === 0);
+  const handler = r && routes[r];
+  if (handler) {
+    handler(req, res);
+    return;
   }
 
   res.setHeader('Content-Type', 'text/plain')
   res.end('Hello World')
-}).listen(port)
+}).listen(port);
+
+// Run this to prevent the server from exiting from an empty event loop
+// This mimics _real_ servers a bit more exactly.
+const keepAlive = setInterval(() => 1, 5000);

--- a/internal/proxy/request.go
+++ b/internal/proxy/request.go
@@ -58,20 +58,3 @@ func NewRequest(e *Input) (*http.Request, error) {
 
 	return req, nil
 }
-
-// basic auth parser.
-func basic(s string) (user, pass string, err error) {
-	p := strings.SplitN(s, " ", 2)
-
-	if len(p) != 2 || p[0] != "Basic" {
-		return "", "", errors.New("malformed")
-	}
-
-	b, err := base64.StdEncoding.DecodeString(p[1])
-	if err != nil {
-		return "", "", errors.Wrap(err, "decoding")
-	}
-
-	pair := strings.SplitN(string(b), ":", 2)
-	return pair[0], pair[1], nil
-}


### PR DESCRIPTION
As a result of https://github.com/apex/up/issues/308, I spent quite a long time debugging up + my application code.

In the end there were errors in both places, for up - I tried to fix and prevent this debugging session from anyone in the future.

1. A network error was assumed to be a process crash, which is not always the case (this was actually causing lambda to run out of file descriptors for processes in this case)
1. A 'bad route' would backoff and retry forever
1. `listen_timeout` can guard against nonsense usage (longer than 30 seconds, when 30 seconds is the APIGateway limit).
1. unused function `basic` in internal/proxy/request.go

It seems that most of these have already been identified as issues, TODOS, so likely nothing surprising here.  I know that I didn't follow the normal "discuss features before implementing them", so feel free to throw all this code away if you like.

**Implementation Strategy**
When the child http server encounters an error, _asynchronously_ ensure it is cleanly shut down by sending a nice SIGINT followed by a SIGKILL after 10 seconds of non-response.  This shutdown process is done in parallel with setting up a new child server (on a separate goroutine) in order to allow the  proxy to serve traffic as fast as possible.  **However** in order to prevent slow shutdowns from causing resource exhaustion like in #308 we make the channel blocking with N=3.  In addition, I tried to add sufficient logging to help future developers debug and understand this in the future.

**Known Bugs**
_none_

**Notable Omissions**
* Even though process shutdown is aysnc from the http serving code, it is still serialized (failing processes aren't cleaned up concurrently with each other)
* SIGKILL delay is not configurable (naming suggestion: shutdown_timeout?).  This would be particularly helpful in tests, since I have added a 10 second test :(
* A failed child process cannot be recognized until another request is made.
* Clean shutdown of relay.Proxy (and cleanup goroutine)
* Concurrent execution: The whole proxy class is serialized on the ServeHTTP entry point, since lambda operates this way anyway - I don't see a strong reason to layer this complexity in until a FaaS adds actual concurrent execution.

