### PR TITLE
test: add tests cases for static config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 # Install the development dependencies.
 install.deps:
 	@echo "==> Installing dev dependencies"
-	@$(GO) get -u /github.com/rsc/gt
+	@$(GO) get -u rsc.io/gt
 	@$(GO) get -u github.com/jteeuwen/go-bindata/...
 	@$(GO) get -u github.com/pointlander/peg/...
 .PHONY: install.deps

--- a/config/static_test.go
+++ b/config/static_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tj/assert"
+)
+
+func TestStatic(t *testing.T) {
+	cwd, _ := os.Getwd()
+
+	table := []struct {
+		dir   Static
+		valid bool
+	}{
+		{Static{Dir: cwd}, true},
+		{Static{Dir: cwd + "/static_test.go"}, false},
+	}
+
+	for _, row := range table {
+		if row.valid {
+			assert.NoError(t, row.dir.Validate())
+		} else {
+			assert.Error(t, row.dir.Validate())
+		}
+	}
+}


### PR DESCRIPTION
Fixed the reference to `gt` in the Makefile and have added some tests for config/static. 

One thing i didn't understand was to ignore errors to non-existent directories in https://github.com/apex/up/blob/master/config/static.go#L28-L30. What is the particular use case?