### PR TITLE
Change checksum name. 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -304,7 +304,7 @@ echo "$PREFIX: found version ${VERSION} for ${OS}/${ARCH}"
 NAME=${BINARY}_${VERSION}_${OS}_${ARCH}
 TARBALL=${NAME}.${FORMAT}
 TARBALL_URL=${GITHUB_DOWNLOAD}/v${VERSION}/${TARBALL}
-CHECKSUM=${BINARY}_checksums.txt
+CHECKSUM=${BINARY}_${VERSION}_checksums.txt
 CHECKSUM_URL=${GITHUB_DOWNLOAD}/v${VERSION}/${CHECKSUM}
 
 # Adjust binary name if windows


### PR DESCRIPTION
The new release 0.2.4 rename the checksum file to up_{version}_checksum however `install.sh` still use the old name, hence throw 404 error when we trying install or upgrade.

This pull request change the checksum in `install.sh` to match the checksum file in release.

fixes #330 
fixes #329 