### PR TITLE
proxy: add failing test and fix for retrying possibly non-idempotent requests

### DIFF
--- a/http/relay/relay.go
+++ b/http/relay/relay.go
@@ -168,11 +168,14 @@ retry:
 
 	// restart the server, try again
 	ctx.WithError(err).Error("network")
-	if err := p.Restart(); err != nil {
-		return nil, errors.Wrap(err, "restarting")
+
+	if restartErr := p.Restart(); restartErr != nil {
+		// We want to restart, but dont want to fail with that error.
+		// The real error was the network error that happened above
+		ctx.WithError(restartErr).Error("restarting")
 	}
 
-	goto retry
+	return nil, errors.Wrap(err, "network")
 }
 
 // environment returns the server env variables.

--- a/http/relay/relay_test.go
+++ b/http/relay/relay_test.go
@@ -179,17 +179,34 @@ func TestRelay(t *testing.T) {
 	})
 
 	t.Run("idempotency", func(t *testing.T) {
-		newHandler(t)
-		r1 := numRestarts()
+		t.Run("POST", func(t *testing.T) {
+			newHandler(t)
+			r1 := numRestarts()
 
-		res := httptest.NewRecorder()
-		req := httptest.NewRequest("POST", "/appError", strings.NewReader("{}"))
-		h.ServeHTTP(res, req)
-		r2 := numRestarts()
+			res := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/appError", strings.NewReader("{}"))
+			h.ServeHTTP(res, req)
+			r2 := numRestarts()
 
-		// This test shoud only restart the server once,
-		// otherwise it incorrectly retried a request
-		assert.Equal(t, r2-r1, 1)
+			// This test shoud only restart the server once,
+			// otherwise it incorrectly retried a request
+			assert.Equal(t, r2-r1, 1)
+		})
+
+		t.Run("get head options", func(t *testing.T) {
+			newHandler(t)
+			for _, m := range []string{"GET", "HEAD", "OPTIONS"} {
+				r1 := numRestarts()
+
+				res := httptest.NewRecorder()
+				req := httptest.NewRequest(m, "/appError", nil)
+				h.ServeHTTP(res, req)
+				r2 := numRestarts()
+
+				// Should restart and retry 3 times
+				assert.Equal(t, r2-r1, 3)
+			}
+		})
 	})
 
 	t.Run("child process cleanup", func(t *testing.T) {

--- a/http/relay/relay_test.go
+++ b/http/relay/relay_test.go
@@ -178,6 +178,20 @@ func TestRelay(t *testing.T) {
 		})
 	})
 
+	t.Run("idempotency", func(t *testing.T) {
+		newHandler(t)
+		r1 := numRestarts()
+
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/appError", strings.NewReader("{}"))
+		h.ServeHTTP(res, req)
+		r2 := numRestarts()
+
+		// This test shoud only restart the server once,
+		// otherwise it incorrectly retried a request
+		assert.Equal(t, r2-r1, 1)
+	})
+
 	t.Run("child process cleanup", func(t *testing.T) {
 
 		// Test that a child process who stops accepting network connections

--- a/http/relay/testdata/basic/app.js
+++ b/http/relay/testdata/basic/app.js
@@ -68,11 +68,10 @@ routes['/close'] = (req, res) => {
 };
 
 routes['/appError'] = (req, res) => {
-  res.writeHead(200, {
+  res.writeHead(500, {
     Connection: 'close'
   });
 
-  // Do some work here
   console.log('Doing some non-idempotent work');
   setTimeout(() => {
     res.socket.end();

--- a/http/relay/testdata/basic/app.js
+++ b/http/relay/testdata/basic/app.js
@@ -69,7 +69,7 @@ routes['/close'] = (req, res) => {
 
 routes['/appError'] = (req, res) => {
   res.writeHead(200, {
-    Connection: 'close',
+    Connection: 'close'
   });
 
   // Do some work here

--- a/http/relay/testdata/basic/app.js
+++ b/http/relay/testdata/basic/app.js
@@ -67,6 +67,18 @@ routes['/close'] = (req, res) => {
   res.end('closed');
 };
 
+routes['/appError'] = (req, res) => {
+  res.writeHead(200, {
+    Connection: 'close',
+  });
+
+  // Do some work here
+  console.log('Doing some non-idempotent work');
+  setTimeout(() => {
+    res.socket.end();
+  }, 10);
+};
+
 routes['/swallowSignals'] = (req, res) => {
   for (const s of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGUSR1', 'SIGUSR2']) {
     process.on(s, () => 1);


### PR DESCRIPTION
When encountering any errors that are not `net.Error` the relay proxy treats them as retry-able.  However, this is incorrect since we can not guarantee that the retried request wasn't idempotent.