### PR TITLE
Request for comments: python 3.6 shim

### DIFF
--- a/internal/shim/proxy.py
+++ b/internal/shim/proxy.py
@@ -1,0 +1,103 @@
+import io
+import json
+import queue
+import subprocess
+import threading
+
+proc = subprocess.Popen(["./main"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True, bufsize=1)
+
+lock = threading.Lock()
+requests = queue.Queue(10)
+
+# a hash of id -> (input_slot, event, output_slot)
+responses = dict()
+
+def send_to_proxy(proxy_stdin):
+    id = 0
+    while True:
+        id = id + 1
+        item = requests.get()
+        if item is None:
+            break
+        cmd = item[0]
+
+        # remove cmd from item, so it can be garbage collected faster
+        item[0] = None
+        cmd['id'] = id
+
+        with lock:
+            responses[id] = item
+
+        proxy_stdin.write(json.dumps(cmd) + '\n')
+        requests.task_done()
+
+def read_from_proxy(proxy_stdout):
+    while True:
+        line = proxy_stdout.readline()
+        if len(line) == 0:
+            raise Exception('EOF from proxy')
+        
+        # even though there will be newlines, json.loads will ignore the whitespace
+        try:
+            resp = json.loads(line)
+        except json.decoder.JSONDecodeError:
+            # ignore lines that can't be parsed as json, someone is misuing stdout
+            continue
+
+        # If the response doesn't have an id, we can't do anything - assume misused stdout
+        if 'id' not in resp:
+            continue
+
+        id  = resp['id']
+        item = None
+        with lock:
+            if id in responses:
+                item = responses[id]
+                del responses[id]
+
+        if item is not None:
+            # set response into output_slot
+            item[2] = resp
+            # notify waiting thread that a response is ready
+            item[1].set()
+
+threading.Thread(target=send_to_proxy, name='send_to_proxy', args=(proc.stdin,)).start()
+threading.Thread(target=read_from_proxy, name='read_from_proxy', args=(proc.stdout,)).start()
+
+def handle(event, context):
+    if context.identity is not None:
+        identity = {
+            'cognitoIdentityId': context.identity.cognito_identity_id,
+            'cognitoIdentityPoolId': context.identity.cognito_identity_pool_id,
+        }
+
+    cmd = {
+        # set id to 0 for now, the 'send_to_proxy' thread will assign it before serializing
+        'id': 0,
+        'event': event,
+        'context': {
+            'awsRequestId': context.aws_request_id,
+            'functionName': context.function_name,
+            'functionVersion': context.function_version,
+            'logGroupName': context.log_group_name,
+            'logStreamName': context.log_stream_name,
+            'memoryLimitInMB': context.memory_limit_in_mb,
+            'clientContext': context.client_context,
+            'identity': identity,
+            'invokedFunctionArn': context.invoked_function_arn,
+        },
+    }
+
+    event = threading.Event()
+
+    # Keep one slot of the list for the response
+    item = [cmd, event, None]
+
+    requests.put(item)
+    event.wait()
+    resp = item[2]
+
+    if 'error' in resp:
+        raise Exception(error)
+
+    return resp['value']

--- a/platform/lambda/lambda.go
+++ b/platform/lambda/lambda.go
@@ -98,7 +98,7 @@ type Platform struct {
 func New(c *up.Config, events event.Events) *Platform {
 	return &Platform{
 		config:  c,
-		runtime: "nodejs6.10",
+		runtime: "python3.6",
 		handler: "_proxy.handle",
 		events:  events,
 	}
@@ -642,6 +642,10 @@ func (p *Platform) injectProxy() error {
 		return errors.Wrap(err, "writing _proxy.js")
 	}
 
+	if err := ioutil.WriteFile("_proxy.py", shim.MustAsset("proxy.py"), 0755); err != nil {
+		return errors.Wrap(err, "writing _proxy.py")
+	}
+
 	return nil
 }
 
@@ -651,6 +655,7 @@ func (p *Platform) removeProxy() error {
 	os.Remove("main")
 	os.Remove("_proxy.js")
 	os.Remove("byline.js")
+	os.Remove("_proxy.py")
 	return nil
 }
 


### PR DESCRIPTION
## tldr
shim written in python3.6 allows up to run python3.6 code. POC for concurrent handler is slow.

## Details
Compared to apex, Up _always_ needs to run the node shim (Since up-proxy is written in go).  However, this prevents native support for all lambda languages.

This _happens_ to work for almost all supported languages since their binaries are embedded into the `nodejs6.10` runtime.

This notably breaks with the python3.6 runtime, since the 'python' available and the `PYTHONPATH` are all in reference to python 2.7.

This PR does 2 things:

1. Demonstrates python3.6 support is possible with up (with no changes elsewhere)
1. Demonstrates a multithreaded capable shim (assume `handler` is called concurrently)

The code to support 1 is dramatically simpler than the current node.js shim, mostly because python comes built in with a line reader.

The code for 2 requires a little extra help from go-apex, to boomerang the ID back to us (since we can receive concurrent responses, and need to tell the difference between them). [apex-go.patch.txt](https://github.com/apex/up/files/1322241/apex-go.patch.txt)

The concurrent proof of concept works, however it _appears_ to be fairly slow, which I need to dig into.

## Suggestions for next steps
After getting some feedback from the community, my suggest to move forward would be to simplify this code back to the single threaded version, make it python 2 and 3 compatible, and deploy this proxy _only_ for python3.6 functions.

If the benchmarks show it is just as fast as the node.js shim, I think the extra simplicity is worth replacing the nodejs shim with this (however my intuition says it will be slower).

**if concurrency is desired from the shim at all** (it may not be)
I suggest throwing out all of the concurrent code pending a refactor of the (shim -> go) communication to vanilla http, gRPC or some sort of request-response IPC framework that has already been performance tuned (vs my hand-rolled producer-consumer model below). 