### PR TITLE
docs: change app.py indentation to fix problem under do_GET function

### DIFF
--- a/docs/03-getting-started.md
+++ b/docs/03-getting-started.md
@@ -61,11 +61,11 @@ import os
 
 class myHandler(BaseHTTPRequestHandler):
   def do_GET(self):
-  self.send_response(200)
-  self.send_header('Content-type','text/html')
-  self.end_headers()
-  self.wfile.write("Hello World from Python\n")
-  return
+      self.send_response(200)
+      self.send_header('Content-type','text/html')
+      self.end_headers()
+      self.wfile.write("Hello World from Python\n")
+      return
 
 server = HTTPServer(('', int(os.environ['PORT'])), myHandler)
 server.serve_forever()


### PR DESCRIPTION
Was preventing hello-world python example from working properly.

```
hello-world-python$ up logs
  11:27:25am FATA error: initializing relay: waiting for http://127.0.0.1:38549 to be in listening state: timed out after 15s
  11:27:25am INFO starting name: task type: server
  11:28:14am INFO found free port 40745 version: $LATEST
  11:28:14am INFO executing "python app.py" version: $LATEST
  11:28:14am INFO proxy (pid=12) started version: $LATEST
  11:28:14am INFO waiting for http://127.0.0.1:40745 to listen (timeout 15s) version: $LATEST
  11:28:14am ERRO   File "app.py", line 6
    self.send_response(200)
       ^
  11:28:29am INFO starting name: task type: server
  11:28:29am INFO found free port 41113 version: $LATEST
  11:28:29am INFO executing "python app.py" version: $LATEST
  11:28:29am INFO proxy (pid=12) started version: $LATEST
  11:28:29am INFO waiting for http://127.0.0.1:41113 to listen (timeout 15s) version: $LATEST
```
