### PR TITLE
docs: fix readme links in docs/

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -2,9 +2,9 @@
 skip: true
 ---
 
-- [Installation](installation.md) – Install the command-line
-- [AWS Credentials](aws-credentials.md) – Set up AWS credentials
-- [Getting Started](getting-started.md) – Get started with deployments
-- [Configuration](configuration.md) – Configuration reference for up.json
-- [Runtimes](runtimes.md) – Runtime specifics
-- [Commands](commands.md) – Command reference
+- [Installation](01-installation.md) – Install the command-line
+- [AWS Credentials](02-aws-credentials.md) – Set up AWS credentials
+- [Getting Started](03-getting-started.md) – Get started with deployments
+- [Configuration](04-configuration.md) – Configuration reference for up.json
+- [Runtimes](05-runtimes.md) – Runtime specifics
+- [Commands](06-commands.md) – Command reference


### PR DESCRIPTION
I'm not sure how this will affect docs on apex.sh but it's fixed on here