### PR TITLE
relay: disable keep alive conns, they interact poorly with suspension

### DIFF
--- a/http/relay/relay_test.go
+++ b/http/relay/relay_test.go
@@ -98,7 +98,8 @@ func TestRelay(t *testing.T) {
     "host": "example.com",
     "user-agent": "tobi",
     "x-forwarded-for": "192.0.2.1",
-    "accept-encoding": "gzip"
+    "accept-encoding": "gzip",
+    "connection": "close"
   },
   "url": "/echo/01BM82CJ9K1WK6EFJX8C1R4YH7/foo%20%25%20bar%20&%20baz%20=%20raz",
   "body": ""
@@ -121,7 +122,8 @@ func TestRelay(t *testing.T) {
     "host": "example.com",
     "content-length": "14",
     "x-forwarded-for": "192.0.2.1",
-    "accept-encoding": "gzip"
+    "accept-encoding": "gzip",
+    "connection": "close"
   },
   "url": "/echo/something",
   "body": "Some body here"

--- a/internal/proxy/request.go
+++ b/internal/proxy/request.go
@@ -2,8 +2,6 @@ package proxy
 
 import (
 	"encoding/base64"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,10 +38,6 @@ func NewRequest(e *Input) (*http.Request, error) {
 	req, err := http.NewRequest(e.HTTPMethod, u.String(), strings.NewReader(body))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
-	}
-
-	req.GetBody = func() (io.ReadCloser, error) {
-		return ioutil.NopCloser(strings.NewReader(body)), nil
 	}
 
 	// remote addr


### PR DESCRIPTION
I expect the `DisableKeepAlives` change to eliminate the EOF / conn reset errors.  Without those errors we would never have found the re-read request body error, which is explicitly addressed by the new `GetBody` code.

A few justifications for the other changes:

1. remove all http.Transport timeouts.  These are generally to prevent "bad" upstream servers, but I think up should try to be as invisible as possible, including not adding additional http timeouts.  We do not know how people will use Up. Maybe they want to use it for delayed `Continue` responses.
1. remove specific `GetBody` code, this is already handled by [http.NewRequest](https://golang.org/src/net/http/request.go?s=25171:25240#L811)
1. Tests show new behavior for disabling keep-alives