### PR TITLE
add support for substituting env vars from shell in environment config

### DIFF
--- a/config/environment.go
+++ b/config/environment.go
@@ -1,4 +1,26 @@
 package config
 
+import (
+	"encoding/json"
+	"os"
+)
+
 // Environment variables.
 type Environment map[string]string
+
+// UnmarshalJSON implementation.
+func (e *Environment) UnmarshalJSON(b []byte) error {
+	valueFromConfig := map[string]string{}
+
+	if err := json.Unmarshal(b, &valueFromConfig); err != nil {
+		return err
+	}
+
+	for k, v := range valueFromConfig {
+		valueFromConfig[k] = os.ExpandEnv(v)
+	}
+
+	*e = valueFromConfig
+
+	return nil
+}

--- a/config/environment_test.go
+++ b/config/environment_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"encoding/json"
+	"github.com/tj/assert"
+	"os"
+	"testing"
+)
+
+func TestEnvironment_UnmarshalJSON(t *testing.T) {
+	t.Run("plain strings", func(t *testing.T) {
+		s := `{
+				"VAR_A": "VALUE_OF_A"
+			}`
+
+		var environment Environment
+
+		err := json.Unmarshal([]byte(s), &environment)
+		assert.NoError(t, err, "unmarshal")
+
+		assert.Equal(t, "VALUE_OF_A", environment["VAR_A"])
+	})
+
+	t.Run("env var substitution", func(t *testing.T) {
+		os.Setenv("EXISTING_ENV_VAR", "EXISTING_ENV_VAR_VALUE")
+		s := `{
+				"VAR_A": "$EXISTING_ENV_VAR"
+			}`
+
+		var environment Environment
+
+		err := json.Unmarshal([]byte(s), &environment)
+		assert.NoError(t, err, "unmarshal")
+
+		assert.Equal(t, "EXISTING_ENV_VAR_VALUE", environment["VAR_A"])
+		os.Unsetenv("EXISTING_ENV_VAR")
+	})
+
+	t.Run("parse error", func(t *testing.T) {
+		s := `{
+				"VAR_A": _INVALID_
+			}`
+
+		var environment Environment
+
+		err := json.Unmarshal([]byte(s), &environment)
+		assert.Error(t, err, "unmarshal")
+	})
+}

--- a/docs/04-configuration.md
+++ b/docs/04-configuration.md
@@ -172,14 +172,15 @@ Note that `static.dir` only tells Up which directory to serve – it does not ex
 
 ## Environment Variables
 
-The `environment` object may be used for plain-text environment variables. Note that these are not encrypted, and are stored in up.json which is typically committed to GIT, so do not store secrets here.
+The `environment` object may be used for plain-text environment variables. It’s possible to use environment variables in your shell to populate values. Note that these are not encrypted, and are stored in up.json which is typically committed to GIT, so do not store secrets here.
 
 ```json
 {
   "name": "api",
   "environment": {
     "API_FEATURE_FOO": "1",
-    "API_FEATURE_BAR": "0"
+    "API_FEATURE_BAR": "0",
+    "API_FEATURE_BAZ": "$BAX_ENABLED"
   }
 }
 ```


### PR DESCRIPTION
No issue created for this feature. Hope it is ok.

PS: This solution can be an alternate for #366 for me.