### PR TITLE
exclude Makefile from todo target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ todo:
 	@grep \
 		--exclude-dir=vendor \
 		--exclude-dir=node_modules \
+		--exclude=Makefile \
 		--text \
 		--color \
 		-nRo -E ' TODO:.*|SkipNow' .


### PR DESCRIPTION
so it wont show the Makefile in the list because of the `TODO:.*|SkipNow` :)

BTW I'm totally copying this!