### PR TITLE
add first class support for Java runtime #390

### DIFF
--- a/config.go
+++ b/config.go
@@ -343,7 +343,7 @@ func javaGradle(c *Config) {
 	}
 
 	if c.Hooks.Clean.IsEmpty() {
-		c.Hooks.Clean = config.Hook{`rm server.jar`}
+		c.Hooks.Clean = config.Hook{`rm server.jar && gradle clean`}
 	}
 }
 
@@ -363,7 +363,7 @@ func javaMaven(c *Config) {
 	}
 
 	if c.Hooks.Clean.IsEmpty() {
-		c.Hooks.Clean = config.Hook{`rm server.jar`}
+		c.Hooks.Clean = config.Hook{`rm server.jar && mvn clean`}
 	}
 }
 


### PR DESCRIPTION
This change provides out of the box support for the Java runtime. It includes being able to build the Java project via Gradle or Maven as well as their respective wrappers (`gradlew` or `mvnw`). If a file named `pom.xml` is found in the project root directory it's assumed the project can be built via Maven. If a file named `build.gradle` is found it's assumed the project is built via Gradle.

There are a couple of assumptions:

1. The Java project will produce a shaded jar with the name `server.jar`.
2. The artifact produced can be run (on port 3000 by default) via `java -jar server.jar`
