### PR TITLE
Fix cert verification email domain is wrong for sub-domains. Closes #425

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -333,7 +333,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context"]
+  packages = ["context","idna","publicsuffix"]
   revision = "c73622c77280266305273cb545f54516ced95b93"
 
 [[projects]]
@@ -342,9 +342,15 @@
   packages = ["unix"]
   revision = "95c6576299259db960f6c5b9b69ea52422860fce"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/text"
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  revision = "88f656faf3f37f690df1a32515b479415e1a6769"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b3bb9746a9f68e2676451e3bbd8ed77cc33298d2b84ab455e5830e8d303c9796"
+  inputs-digest = "204fa3bc4ee08693c4d68045ef0aee551af08a6fe2748f03c7d190ab0f0e1da6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -345,6 +345,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e2c04dbc8df23516269e7af4751d0e4f834a475b097007a5f430b9b452fc4f21"
+  inputs-digest = "b3bb9746a9f68e2676451e3bbd8ed77cc33298d2b84ab455e5830e8d303c9796"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/internal/logs/parser/grammar.peg.go
+++ b/internal/logs/parser/grammar.peg.go
@@ -1,5 +1,7 @@
 package parser
 
+//go:generate peg -inline -switch grammar.peg
+
 import (
 	"github.com/apex/up/internal/logs/parser/ast"
 	"fmt"

--- a/platform/lambda/lambda.go
+++ b/platform/lambda/lambda.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/publicsuffix"
+
 	"github.com/apex/log"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -342,9 +344,25 @@ func (p *Platform) createCerts() error {
 			continue
 		}
 
+		parentDomain, err := publicsuffix.EffectiveTLDPlusOne(s.Domain)
+
+		if err != nil {
+			return errors.Wrapf(err, "getting parent domain for %s", s.Domain)
+		}
+
+		option := acm.DomainValidationOption{
+			DomainName:       &s.Domain,
+			ValidationDomain: &parentDomain,
+		}
+
+		options := []*acm.DomainValidationOption{
+			&option,
+		}
+
 		// request the cert
 		res, err := a.RequestCertificate(&acm.RequestCertificateInput{
-			DomainName: &s.Domain,
+			DomainName:              &s.Domain,
+			DomainValidationOptions: options,
 		})
 
 		if err != nil {


### PR DESCRIPTION
Finds the base domain using `publicsuffix.EffectiveTLDPlusOne()`. Fixes the sub-domain issue here: #425 

Note I won’t be offended if you want to refactor the code a lot — **Not sure if I did the dep stuff correctly**. I have not used Go all that much.