### PR TITLE
docs: change default lambda.memory

### DIFF
--- a/docs/04-configuration.md
+++ b/docs/04-configuration.md
@@ -92,7 +92,7 @@ Currently Lambda supports the following regions:
 The following Lambda-specific settings are available:
 
 - `role` – IAM role ARN, defaulting to the one Up creates for you
-- `memory` – Function memory in mb (Default `128`, Min `128`, Max `1536`)
+- `memory` – Function memory in mb (Default `512`, Min `128`, Max `1536`)
 
 For example:
 


### PR DESCRIPTION
Changes default lambda.memory to match change in 25fa10ea5e405f169fe48dff9f04970de6a3f126