### PR TITLE
Update regions.go

### DIFF
--- a/platform/lambda/regions/regions.go
+++ b/platform/lambda/regions/regions.go
@@ -19,6 +19,7 @@ var IDs = []string{
 	"eu-west-1",
 	"eu-west-2",
 	"sa-east-1",
+	"cn-north-1",
 }
 
 // Names of regions.
@@ -37,6 +38,7 @@ var Names = []string{
 	"EU (Ireland)",
 	"EU (London)",
 	"South America (São Paulo)",
+	"North China (Beijing)",
 }
 
 // Match returns regions matching the pattern(s) provided. Patterns


### PR DESCRIPTION
So, after this update, I am able to use region `cn-north-1` via `~/.aws/credentials`;
But while deploying, up says the token is invalid;

```bash
$ go run /Users/timqian/go/src/github.com/apex/up/cmd/up/main.go

     build: 11,132 files, 37 MB (7.613s)
*
*
*     1ms     DEBU hook deploy is not defined
   ⠦ 1.613s  DEBU checking for role
     1.651s  DEBU checking for role
   ⠧ 0s      DEBU event deploy.complete map[duration:10.733499608s]
     Error: deploying: deploying: iam: fetching role: InvalidClientTokenId: The security token included in the request is invalid.
        status code: 403, request id: f0ec4bc7-e0a6-11e7-9ddd-5567534e8301

exit status 1
```

But I am able to access aws via `aws-cli`
```bash
$ aws iam get-user --user-name tim
{
    "User": {
        "UserName": "tim",
        "PasswordLastUsed": "2017-10-27T08:55:51Z",
        "CreateDate": "2016-12-12T05:23:48Z",
        "UserId": "A******E",
        "Path": "/",
        "Arn": "arn:aws-cn:iam::4******0:user/tim"
    }
}
```
```js
// up.json
{
  "profile": "tim",
  "name":"bimapi",
  "environment": {
    "ON_LAMBDA": "true"
  },
  "hooks": {
    "build": "make"
  },
  "proxy": {
    "command": "./node-v9.2.0-linux-x64/bin/node src/server.js"
  }
}
```