### PR TITLE
fix: goroutine leak in lambda report

### DIFF
--- a/platform/lambda/stack/stack.go
+++ b/platform/lambda/stack/stack.go
@@ -370,7 +370,10 @@ func (s *Stack) report(states map[string]Status) error {
 		"complete": 0,
 	})()
 
-	for range time.Tick(time.Second) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
 		stack, err := s.getStack()
 
 		if util.IsNotFound(err) {


### PR DESCRIPTION
`time.Tick` leaks its goroutine since it's not manageable. Instead, new ticker is created and deferred to stop as soon as function returns.
