### PR TITLE
refactor: remove unnecessary parts

### DIFF
--- a/internal/logs/parser/ast/ast.go
+++ b/internal/logs/parser/ast/ast.go
@@ -55,7 +55,7 @@ type Literal string
 
 // String implementation.
 func (n Literal) String() string {
-	return fmt.Sprintf(`%s`, string(n))
+	return string(n)
 }
 
 // Tuple node.
@@ -77,7 +77,7 @@ func (n Contains) String() string {
 	case String:
 		return fmt.Sprintf(`"*%s*"`, string(v))
 	default:
-		return fmt.Sprintf(`%s`, n.Node)
+		return n.Node.String()
 	}
 }
 

--- a/platform/lambda/cost/cost.go
+++ b/platform/lambda/cost/cost.go
@@ -39,7 +39,7 @@ var memoryConfigurations = map[int]float64{
 
 // Requests returns the cost for the given number of http requests.
 func Requests(n int) float64 {
-	return (float64(n) / float64(requestUnit)) * float64(pricePerRequestUnit)
+	return (float64(n) / requestUnit) * pricePerRequestUnit
 }
 
 // Rate returns the cost per 100ms for the given `memory` configuration in megabytes.


### PR DESCRIPTION
Tiny improvements:
 * type conversion: constants are typeless
 * function call: no need to pipe string to `fmt.Sprintf`
