### PR TITLE
fix: add a ! in front of build.gradle

### DIFF
--- a/internal/zip/zip.go
+++ b/internal/zip/zip.go
@@ -44,7 +44,7 @@ func Build(dir string) (io.ReadCloser, *archive.Stats, error) {
 		gitignore,
 		strings.NewReader("\n!node_modules/**\n!.pypath/**\n"),
 		upignore,
-		strings.NewReader("\n!main\n!server\n!_proxy.js\n!byline.js\n!up.json\n!pom.xml\nbuild.gradle\n"))
+		strings.NewReader("\n!main\n!server\n!_proxy.js\n!byline.js\n!up.json\n!pom.xml\n!build.gradle\n"))
 
 	filter, err := archive.FilterPatterns(r)
 	if err != nil {


### PR DESCRIPTION
As discuted in https://github.com/apex/up-examples/issues/60 Gradle based projects can not run.
The build.gradle file is always excluded from the out.zip file.
This PR allows to include build.gradle in out.zip.