### PR TITLE
add wildcard ACM certs back

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -363,6 +363,23 @@ func Domain(s string) string {
 	return d
 }
 
+// CertDomainName returns the certificate domain name. For example
+// the string "example.com" becomes "*.example.com",
+// while "sub.api.example.co.uk" becomes "*.api.example.co.uk".
+func CertDomainName(s string) string {
+	d := Domain(s)
+	if d == s {
+		// Effective TLD plus one
+		return "*." + s
+	}
+	// Effective TLD plus two (or more)
+	idx := strings.Index(s, ".")
+	if idx == -1 {
+		panic(errors.Errorf("cert domain name: %s", s))
+	}
+	return "*" + s[idx:]
+}
+
 // ParseSections returns INI style sections from r.
 func ParseSections(r io.Reader) (sections []string, err error) {
 	s := bufio.NewScanner(r)

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -85,6 +85,12 @@ func TestDomain(t *testing.T) {
 	assert.Equal(t, "example.co.uk", Domain("v1.api.example.co.uk"))
 }
 
+func TestCertDomainName(t *testing.T) {
+	assert.Equal(t, "*.example.com", CertDomainName("example.com"))
+	assert.Equal(t, "*.example.com", CertDomainName("api.example.com"))
+	assert.Equal(t, "*.api.example.com", CertDomainName("v1.api.example.com"))
+}
+
 func TestParseSections(t *testing.T) {
 	r := strings.NewReader(`[personal]
 aws_access_key_id = personal_key

--- a/platform/lambda/lambda_test.go
+++ b/platform/lambda/lambda_test.go
@@ -1,0 +1,31 @@
+package lambda
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/tj/assert"
+)
+
+func TestGetCert(t *testing.T) {
+	certs := []*acm.CertificateSummary{
+		{
+			DomainName:     aws.String("example.com"),
+			CertificateArn: aws.String("arn:example.com"),
+		},
+		{
+			DomainName:     aws.String("*.example.com"),
+			CertificateArn: aws.String("arn:*.example.com"),
+		},
+	}
+
+	certArn := getCert(certs, "example.com")
+	assert.Equal(t, "arn:example.com", certArn)
+
+	certArn = getCert(certs, "sub.example.com")
+	assert.Equal(t, "arn:*.example.com", certArn)
+
+	certArn = getCert(certs, "www.sub.example.com")
+	assert.Equal(t, "", certArn)
+}


### PR DESCRIPTION
Closes: #452 

Some notes:
- deploy & stack delete completes successfully and cert is not removed :-) (cert preconfigured)
- deploy & stack delete completes successfully (cert created by up)
- Validation email for wildcard domain "*.sub.example.com" is admin@example.com. I was expecting admin@sub.example.com..


