### PR TITLE
change UP_CONFIG to attempt base64-decode when not JSON

### DIFF
--- a/internal/userconfig/userconfig.go
+++ b/internal/userconfig/userconfig.go
@@ -2,11 +2,13 @@
 package userconfig
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/apex/up/internal/util"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 )
@@ -123,6 +125,15 @@ func (c *Config) Load() error {
 
 	// env
 	if s := os.Getenv(envName); s != "" {
+		// if not JSON, check for base64 encoding
+		if !util.IsJSON(s) {
+			decoded, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return errors.Wrap(err, "decoding base64")
+			}
+			s = string(decoded)
+		}
+
 		if err := json.Unmarshal([]byte(s), &c); err != nil {
 			return errors.Wrap(err, "unmarshaling")
 		}


### PR DESCRIPTION
This is meant to address #593 and since it was trivial to implement I decided to open a PR where discussion could also take place.

When loading config via `$UP_CONFIG`, it will check to see if the value is JSON. If not, it will attempt to base64-decode that string before attempting to unmarshal as JSON.