### PR TITLE
Increase max timeout to 300 seconds

### DIFF
--- a/config/relay.go
+++ b/config/relay.go
@@ -87,8 +87,8 @@ func (r *Relay) Validate() error {
 		return errors.Wrap(err, ".listen_timeout")
 	}
 
-	if r.platform == "lambda" && r.Timeout > 25 {
-		err := errors.New("should be <= 25")
+	if r.platform == "lambda" && r.Timeout > 300 {
+		err := errors.New("should be <= 300")
 		return errors.Wrap(err, ".timeout")
 	}
 

--- a/docs/04-configuration.md
+++ b/docs/04-configuration.md
@@ -462,7 +462,7 @@ The following settings are available:
   - When `app.py` is detected `python app.py` is used
 - `backoff` – Backoff configuration object described in "Crash Recovery"
 - `retry` – Retry idempotent requests upon 5xx or server crashes. (Default `true`)
-- `timeout` – Timeout in seconds per request (Default `15`, Max `25`)
+- `timeout` – Timeout in seconds per request (Default `15`, Max `300`)
 - `listen_timeout` – Timeout in seconds Up will wait for your app to boot and listen on `PORT` (Default `15`, Max `25`)
 - `shutdown_timeout` – Timeout in seconds Up will wait after sending a SIGINT to your server, before sending a SIGKILL (Default `15`)
 


### PR DESCRIPTION
Lambda's maximum timeout is 300 seconds.  The max value that `up` allows is 25 seconds.  In my case, I want my lambda to be able to do some processing that can potentially take longer than 25 seconds.

This PR modifies the max timeout to 300 seconds to match lambda.
