### PR TITLE
add hidden disable stats command

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/apex/up/internal/cli/build"
 	_ "github.com/apex/up/internal/cli/config"
 	_ "github.com/apex/up/internal/cli/deploy"
+	_ "github.com/apex/up/internal/cli/disable-stats"
 	_ "github.com/apex/up/internal/cli/docs"
 	_ "github.com/apex/up/internal/cli/domains"
 	_ "github.com/apex/up/internal/cli/logs"

--- a/internal/cli/disable-stats/disable-stats.go
+++ b/internal/cli/disable-stats/disable-stats.go
@@ -1,0 +1,20 @@
+package disablestats
+
+import (
+	"github.com/pkg/errors"
+	"github.com/tj/kingpin"
+
+	"github.com/apex/up/internal/cli/root"
+	"github.com/apex/up/internal/stats"
+)
+
+func init() {
+	cmd := root.Command("disable-stats", "Disable anonymized usage stats").Hidden()
+	cmd.Action(func(_ *kingpin.ParseContext) error {
+		err := stats.Client.Disable()
+		if err != nil {
+			return errors.Wrap(err, "disabling")
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
As discussed on Slack, I'm unable to send anonymized usage stats for various reasons. This patch makes disabling the stats much easier, as no prior knowledge of `go-cli-analytics` is required.