### PR TITLE
Fix Crystal build on Linux: PWD => pwd

### DIFF
--- a/config/runtimes.go
+++ b/config/runtimes.go
@@ -150,7 +150,7 @@ func clojureLein(c *Config) {
 // crystal config.
 func crystal(c *Config) {
 	if c.Hooks.Build.IsEmpty() {
-		c.Hooks.Build = Hook{`docker run --rm -v $(PWD):/src -w /src tjholowaychuk/up-crystal crystal build --link-flags -static -o server main.cr`}
+		c.Hooks.Build = Hook{`docker run --rm -v $(pwd):/src -w /src tjholowaychuk/up-crystal crystal build --link-flags -static -o server main.cr`}
 	}
 
 	if c.Hooks.Clean.IsEmpty() {

--- a/docs/05-runtimes.md
+++ b/docs/05-runtimes.md
@@ -65,7 +65,7 @@ When a `main.cr` file is detected, Crystal is the assumed runtime. Note that thi
 The `build` hook becomes:
 
 ```
-$ docker run --rm -v $(PWD):/src -w /src tjholowaychuk/up-crystal crystal build --link-flags -static -o server main.cr
+$ docker run --rm -v $(pwd):/src -w /src tjholowaychuk/up-crystal crystal build --link-flags -static -o server main.cr
 ```
 
 The `clean` hook becomes:


### PR DESCRIPTION
Crystal build uses PWD instead of pwd, which fails on case-sensitive operating systems and filesystems, e.g. Linux