### PR TITLE
docs: Fix default stage of "up" and "up deploy"

### DIFF
--- a/docs/06-commands.md
+++ b/docs/06-commands.md
@@ -110,22 +110,16 @@ Args:
 
 ### Examples
 
-Deploy the project to the development stage.
+Deploy the project to the staging stage.
 
 ```
 $ up
 ```
 
-Deploy the project to the development stage, this is the same as running `up` without arguments.
+Deploy the project to the staging stage, this is the same as running `up` without arguments.
 
 ```
 $ up deploy
-```
-
-Deploy the project to the staging stage.
-
-```
-$ up deploy staging
 ```
 
 Deploy the project to the production stage.
@@ -134,10 +128,9 @@ Deploy the project to the production stage.
 $ up deploy production
 ```
 
-Note that since `deploy` is the default command the following are also valid:
+Note that since `deploy` is the default command the following is also valid:
 
 ```
-$ up staging
 $ up production
 ```
 


### PR DESCRIPTION
According to other parts of the documentation and also according to the code the default stage is "staging" and not "development".
See code at latest commit for that file: https://github.com/apex/up/blob/6d27f34c95c7eeba660d54a8ff7c6e48c69f6769/internal/cli/deploy/deploy.go#L22

Note: Only the PR header contains the "docs: " prefix. Is this enough for the filtering of the release notes, or do I need to change the commit?