### PR TITLE
updates max memory in lambda settings doc

### DIFF
--- a/docs/04-configuration.md
+++ b/docs/04-configuration.md
@@ -93,7 +93,7 @@ Currently Lambda supports the following regions:
 The following Lambda-specific settings are available:
 
 - `role` – IAM role ARN, defaulting to the one Up creates for you
-- `memory` – Function memory in mb (Default `512`, Min `128`, Max `1536`)
+- `memory` – Function memory in mb (Default `512`, Min `128`, Max `3008`)
 - `policy` – IAM function policy statement(s)
 - `vpc` - VPC subnets and security groups
 


### PR DESCRIPTION
The limit on AWS is now 3008 Mb - at least I can verify that I have uploaded a function with 2048 Mb using `up`.

Open an issue and discuss changes before spending time on them, unless the change is trivial or an issue already exists.

Use "VERB some thing here. Closes #n" to close the relevant issue, where VERB is one of:

  - add
  - remove
  - change
  - refactor

If the change is documentation related prefix with "docs: ", as these are filtered from the changelog.

  docs: add ~/.aws/config

Run `dep ensure` if you introduce any new `import`'s so they're included in the ./vendor dir.
