### PR TITLE
Fix json code block

### DIFF
--- a/docs/02-aws-credentials.md
+++ b/docs/02-aws-credentials.md
@@ -37,6 +37,7 @@ If you're using Up for a production application it's highly recommended to confi
 
 <details>
   <summary>Show policy</summary>
+  
 ```json
 {
     "Version": "2012-10-17",
@@ -92,4 +93,5 @@ If you're using Up for a production application it's highly recommended to confi
     ]
 }
 ```
+
 </details>


### PR DESCRIPTION
When you click on "Show policy" it wasn't formatting the `json` code block correctly before. The newlines seem to fix that.