### PR TITLE
docs: fix typo in guides.md

### DIFF
--- a/docs/07-guides.md
+++ b/docs/07-guides.md
@@ -688,7 +688,7 @@ Note that the server must always listen on `PORT` which is provided by `up start
 
 ## Accessing Lambda Context
 
-Traditional AWS Lambda functions a provided a context object which contains runtime information such as API Gateway user identity. This information is exposed as JSON in the `X-Context` header field in Up as shown here:
+Traditional AWS Lambda functions provided a context object which contains runtime information such as API Gateway user identity. This information is exposed as JSON in the `X-Context` header field in Up as shown here:
 
 ```js
 const http = require('http')


### PR DESCRIPTION
Open an issue and discuss changes before spending time on them, unless the change is trivial or an issue already exists.

Use "VERB some thing here. Closes #n" to close the relevant issue, where VERB is one of:

  - add
  - remove
  - change
  - refactor

If the change is documentation related prefix with "docs: ", as these are filtered from the changelog.

  docs: add ~/.aws/config

Run `dep ensure` if you introduce any new `import`'s so they're included in the ./vendor dir.
