### PR TITLE
Update references to Staging in docs

### DIFF
--- a/docs/06-commands.md
+++ b/docs/06-commands.md
@@ -414,19 +414,19 @@ Flags:
 
 ### Examples
 
-Show the development endpoint.
+Show the staging endpoint.
 
 ```
 $ up url
 ```
 
-Open the development endpoint in the browser.
+Open the staging endpoint in the browser.
 
 ```
 $ up url --open
 ```
 
-Copy the development endpoint to the clipboard.
+Copy the staging endpoint to the clipboard.
 
 ```
 $ up url --copy

--- a/docs/07-guides.md
+++ b/docs/07-guides.md
@@ -228,7 +228,7 @@ You should see "Hello World from production" and "Hello World from staging".
 
 Now that you have an application deployed, you probably want a fancy custom domain for it right? You can map these using the `stages` and `domain` properties.
 
-Here we let Up know that we want `up-example.com` for production and `dev.up-example` for staging.
+Here we let Up know that we want `up-example.com` for production and `stage.up-example` for staging.
 
 ```json
 {
@@ -236,7 +236,7 @@ Here we let Up know that we want `up-example.com` for production and `dev.up-exa
   "profile": "up-tobi",
   "stages": {
     "staging": {
-      "domain": "dev.up-example.com"
+      "domain": "stage.up-example.com"
     },
     "production": {
       "domain": "up-example.com"
@@ -303,7 +303,7 @@ $ up stack apply
 
 After the changes have been applied, it can take roughly 10-40 minutes for CloudFront to distribute the configuration and SSL certificate globally, so until then our up-example.com domain won't work.
 
-Once available https://up-example.com will always point to production via `up deploy production`, and https://dev.up-example.com/ will point to the latest deployment via `up`.
+Once available https://up-example.com will always point to production via `up deploy production`, and https://stage.up-example.com/ will point to the latest deployment via `up`.
 
 ### Mapping Domains from External Registrars
 

--- a/docs/07-guides.md
+++ b/docs/07-guides.md
@@ -228,7 +228,7 @@ You should see "Hello World from production" and "Hello World from staging".
 
 Now that you have an application deployed, you probably want a fancy custom domain for it right? You can map these using the `stages` and `domain` properties.
 
-Here we let Up know that we want `up-example.com` for production and `stage.up-example` for staging.
+Here we let Up know that we want `up-example.com` for production and `stage.up-example.com` for staging.
 
 ```json
 {


### PR DESCRIPTION
There seems to be some documentation drift between "development" and "staging" environments.

Sometimes the subdomain is `stage.` 

```
Staging
  domain: stage.up-example.com
```

...and other's it's `dev.`

```
"stages": {
    "staging": {
      "domain": "dev.up-example.com"
    },
```

Minor changes:

* Change all occurrences of "development" to "staging" when it comes to
the default `up` commands.
* Update all `dev.` URLs to `stage.`

