### PR TITLE
fixes #636

### DIFF
--- a/http/static/static.go
+++ b/http/static/static.go
@@ -44,6 +44,13 @@ func NewDynamic(c *up.Config, next http.Handler) http.Handler {
 		if !skip {
 			file := filepath.Join(dir, path)
 			info, err := os.Stat(file)
+
+			// http.ServeFile rewrites Path/index.html to Path/, so play along
+			if !os.IsNotExist(err) && info.IsDir() {
+				file = filepath.Join(file, "index.html")
+				info, err = os.Stat(file)
+			}
+
 			if !os.IsNotExist(err) && !info.IsDir() {
 				http.ServeFile(w, r, file)
 				return

--- a/http/static/static.go
+++ b/http/static/static.go
@@ -46,7 +46,7 @@ func NewDynamic(c *up.Config, next http.Handler) http.Handler {
 			info, err := os.Stat(file)
 
 			// http.ServeFile rewrites Path/index.html to Path/, so play along
-			if !os.IsNotExist(err) && info.IsDir() {
+			if !os.IsNotExist(err) && info.IsDir() && strings.HasSuffix(path, "/") {
 				file = filepath.Join(file, "index.html")
 				info, err = os.Stat(file)
 			}

--- a/http/static/static_test.go
+++ b/http/static/static_test.go
@@ -98,6 +98,17 @@ func TestStatic_dynamic(t *testing.T) {
 		fmt.Fprintln(w, ":)")
 	}))
 
+	t.Run("index.html", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/", nil)
+
+		h.ServeHTTP(res, req)
+
+		assert.Equal(t, 200, res.Code)
+		assert.Equal(t, "text/html; charset=utf-8", res.Header().Get("Content-Type"))
+		assert.Equal(t, "Index HTML\n", res.Body.String())
+	})
+
 	t.Run("file", func(t *testing.T) {
 		res := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/css/style.css", nil)

--- a/http/static/testdata/dynamic/public/index.html
+++ b/http/static/testdata/dynamic/public/index.html
@@ -1,0 +1,1 @@
+Index HTML


### PR DESCRIPTION
serves static "file" `Path/`, by preemptively reversing `http.ServeFile()` unconditional translation of `Path/index.html` to `Path/`