### PR TITLE
Add Rust runtime

### DIFF
--- a/config/runtimes.go
+++ b/config/runtimes.go
@@ -15,6 +15,7 @@ const (
 	RuntimeUnknown    Runtime = "unknown"
 	RuntimeGo                 = "go"
 	RuntimeNode               = "node"
+	RuntimeRust               = "rust"
 	RuntimeClojure            = "clojure"
 	RuntimeCrystal            = "crystal"
 	RuntimePython             = "python"
@@ -28,6 +29,8 @@ func inferRuntime() Runtime {
 	switch {
 	case util.Exists("main.go"):
 		return RuntimeGo
+	case util.Exists("Cargo.toml"):
+		return RuntimeRust
 	case util.Exists("main.cr"):
 		return RuntimeCrystal
 	case util.Exists("package.json"):
@@ -54,6 +57,8 @@ func runtimeConfig(runtime Runtime, c *Config) error {
 	switch runtime {
 	case RuntimeGo:
 		golang(c)
+	case RuntimeRust:
+		rust(c)
 	case RuntimeClojure:
 		clojureLein(c)
 	case RuntimeJavaMaven:
@@ -87,6 +92,23 @@ func golang(c *Config) {
 	if s := c.Stages.GetByName("development"); s != nil {
 		if s.Proxy.Command == "" {
 			s.Proxy.Command = "go run *.go"
+		}
+	}
+}
+
+// rust config.
+func rust(c *Config) {
+	if c.Hooks.Build.IsEmpty() {
+		c.Hooks.Build = Hook{`cargo build --release --target x86_64-unknown-linux-gnu`}
+	}
+
+	if c.Hooks.Clean.IsEmpty() {
+		c.Hooks.Clean = Hook{`rm -rf target`}
+	}
+
+	if s := c.Stages.GetByName("development"); s != nil {
+		if s.Proxy.Command == "" {
+			s.Proxy.Command = "cargo run"
 		}
 	}
 }

--- a/config/runtimes.go
+++ b/config/runtimes.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/apex/up/internal/util"
@@ -99,11 +100,14 @@ func golang(c *Config) {
 // rust config.
 func rust(c *Config) {
 	if c.Hooks.Build.IsEmpty() {
-		c.Hooks.Build = Hook{`cargo build --release --target x86_64-unknown-linux-gnu`}
+		c.Hooks.Build = Hook{
+			`cargo build --release --target x86_64-unknown-linux-musl`,
+			fmt.Sprintf("cp target/x86_64-unknown-linux-musl/release/%s ./server", c.Name),
+		}
 	}
 
 	if c.Hooks.Clean.IsEmpty() {
-		c.Hooks.Clean = Hook{`rm -rf target`}
+		c.Hooks.Clean = Hook{`rm -rf target && rm server`}
 	}
 
 	if s := c.Stages.GetByName("development"); s != nil {

--- a/docs/05-runtimes.md
+++ b/docs/05-runtimes.md
@@ -58,6 +58,22 @@ The `clean` hook becomes:
 $ rm server
 ```
 
+## Rust
+
+When a `Cargo.toml` file is detected, Rust is the assumed runtime. You must have cross-compilation setup to be able to compile targeting `x86_64-unknown-linux-musl`.
+
+The `build` hook becomes:
+
+```
+$ cargo build --release --target x86_64-unknown-linux-musl && cp target/x86_64-unknown-linux-musl/release/<project-name> ./server
+```
+
+The `clean` hook becomes:
+
+```
+$ rm -rf target && rm server
+```
+
 ## Crystal
 
 When a `main.cr` file is detected, Crystal is the assumed runtime. Note that this runtime requires Docker to be installed.


### PR DESCRIPTION
Tried seeing if their official docker image would make things easier, but honestly just setting up the cross-compilation stuff to target `x86_64-unknown-linux-musl` was the easiest, and actually pretty straightforward.

Not sure if we want to add things into the readme about how to do that, or just leave it as "you have to".