### PR TITLE
nodejs10.x support

### DIFF
--- a/config/lambda.go
+++ b/config/lambda.go
@@ -56,7 +56,7 @@ func (l *Lambda) Default() error {
 	}
 
 	if l.Runtime == "" {
-		l.Runtime = "nodejs8.10"
+		l.Runtime = "nodejs10.x"
 	}
 
 	l.Policy = append(l.Policy, defaultPolicy)

--- a/docs/05-runtimes.md
+++ b/docs/05-runtimes.md
@@ -14,7 +14,7 @@ Up supports a number of interpreted languages, and virtually any language which 
 
 ## Node.js
 
-When a `package.json` file is detected, Node.js is the assumed runtime. By default the latest version supported by Lambda is used (nodejs8.10), see [Lambda Settings](#configuration.lambda_settings) for details.
+When a `package.json` file is detected, Node.js is the assumed runtime. By default the latest version supported by Lambda is used (nodejs10.x), see [Lambda Settings](#configuration.lambda_settings) for details.
 
 The `build` hook becomes:
 


### PR DESCRIPTION
AWS released support for node.js v10 runtime.
https://aws.amazon.com/about-aws/whats-new/2019/05/aws_lambda_adds_support_for_node_js_v10/

- update default node.js runtime
- update latest node.js version in doc