### PR TITLE
Change stack delete behavior to not attempt to delete configured lambda roles. (Closes #787)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Before contributing to Up you'll need a few things:
 The following are optional:
 
 - Install [pointlander/peg](https://github.com/pointlander/peg) if you're working on the log grammar
-- Install [jteeuwen/go-bindata](https://github.com/jteeuwen/go-bindata) if you need to bake `up-proxy` into `up`
+- Install [shuLhan/go-bindata](https://github.com/shuLhan/go-bindata) if you need to bake `up-proxy` into `up`
 
 ## Setup
 
@@ -43,7 +43,7 @@ Although Up is not provided as a library it is structured as if it was, for orga
 - [config](config) – Configuration structures and validation for `up.json`
 - [cmd](cmd) – Commands, where `up` is the CLI and `up-proxy` is serving requests in production
 
-Note that this is just a first past, and the code / layout will be refactored. View [Godoc](http://godoc.org/github.com/apex/up) for more details of the internals.
+Note that this is just a first pass, and the code / layout will be refactored. View [Godoc](http://godoc.org/github.com/apex/up) for more details of the internals.
 
 ## Proxy
 

--- a/platform/lambda/lambda.go
+++ b/platform/lambda/lambda.go
@@ -814,6 +814,12 @@ func (p *Platform) roleName() string {
 func (p *Platform) deleteRole(region string) error {
 	name := fmt.Sprintf("%s-function", p.config.Name)
 	c := iam.New(session.New(aws.NewConfig().WithRegion(region)))
+	
+	// role is provided
+	if s := p.config.Lambda.Role; s != "" {
+		log.Debugf("using role from config %s; not deleting", s)
+		return nil
+	}
 
 	_, err := c.DeleteRolePolicy(&iam.DeleteRolePolicyInput{
 		RoleName:   &name,

--- a/platform/lambda/lambda_test.go
+++ b/platform/lambda/lambda_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/tj/assert"
+	
+	"github.com/apex/up/config"
+	"github.com/apex/up/platform/event"
 )
 
 func TestGetCert(t *testing.T) {
@@ -54,4 +57,30 @@ func TestGetCert(t *testing.T) {
 
 	arn = getCert(certs, "staging.v1.api.example.com")
 	assert.Empty(t, arn)
+}
+
+func TestCreateRole(t *testing.T) {
+	t.Run("doesn't attempt to create configured role", func(t *testing.T) {
+		c := &config.Config{
+			Lambda: config.Lambda{
+				Role: "custom-role-name",
+			},
+		}
+		events := make(event.Events)
+		p := New(c, events)
+		assert.NoError(t, p.createRole(), "createRole")
+	})
+}
+
+func TestDeleteRole(t *testing.T) {
+	t.Run("doesn't attempt to delete configured role", func(t *testing.T) {
+		c := &config.Config{
+			Lambda: config.Lambda{
+				Role: "custom-role-name",
+			},
+		}
+		events := make(event.Events)
+		p := New(c, events)
+		assert.NoError(t, p.deleteRole("us-west-2"), "deleteRole")
+	})
 }


### PR DESCRIPTION
See https://github.com/apex/up/issues/787 for more details.