### PR TITLE
Change javaGradle runtime behavior to use gradlew for cleaning when present. (Closes #782)

### DIFF
--- a/config/runtimes.go
+++ b/config/runtimes.go
@@ -107,7 +107,11 @@ func javaGradle(c *Config) {
 	}
 
 	if c.Hooks.Clean.IsEmpty() {
-		c.Hooks.Clean = Hook{`rm server.jar && gradle clean`}
+		if util.Exists("gradlew") {
+			c.Hooks.Clean = Hook{`rm server.jar && ./gradlew clean`}
+		} else {
+			c.Hooks.Clean = Hook{`rm server.jar && gradle clean`}
+		}
 	}
 }
 


### PR DESCRIPTION
See https://github.com/apex/up/issues/782 for more details.