### PR TITLE
change timeout through UP-TIMEOUT header. Closes #814

### DIFF
--- a/http/relay/relay.go
+++ b/http/relay/relay.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 
@@ -145,7 +146,11 @@ func (p *Proxy) Restart() error {
 func (p *Proxy) RoundTrip(r *http.Request) (*http.Response, error) {
 	id := r.Header.Get("X-Request-Id")
 	ctx = ctx.WithField("id", id)
-
+	if timeout, err := strconv.ParseInt(r.Header.Get("UP-TIMEOUT"), 10, 64); err == nil {
+		p.transport = &http.Transport{
+			ResponseHeaderTimeout: time.Duration(timeout) * time.Second,
+		}
+	}
 	res, err := p.transport.RoundTrip(r)
 
 	// timeout error

--- a/http/relay/relay_test.go
+++ b/http/relay/relay_test.go
@@ -144,6 +144,15 @@ func TestRelay(t *testing.T) {
 
 		assert.Equal(t, 200, res.Code)
 		assertString(t, "Hello World", res.Body.String())
+
+		// third
+		res = httptest.NewRecorder()
+		req = httptest.NewRequest("GET", "/timeout", nil)
+		req.Header.Add("UP-TIMEOUT", "0");
+		h.ServeHTTP(res, req)
+
+		assert.Equal(t, 200, res.Code)
+		assertString(t, "Hello", res.Body.String())
 	})
 }
 


### PR DESCRIPTION
See #814 

This change allows the timeout to be increased when calling lambda directly while keeping the timeout specified in the config as a default.

The tests run for 50seconds longer now because that's how long the timeout is set, let me know if I should reduce it.